### PR TITLE
Add ability to parse AOE2 rms (Random Map Script) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ age-archive extract --directory graphics graphics.drs
 age-slp extract graphics/177.slp --palette interfac/50500.bin --player 3 --directory output/
 ```
 
+Show an XML representation of the parameters in an AOE2 random map script (`*.rms` file):
+
+```
+age-rms validate Arabia.rms | xmllint -format -
+```
+
 ## Attribution
 
 - `dat`, `scn` and `drs` format handling is directly based on [SiegeEngineers/genie-rs](https://github.com/SiegeEngineers/genie-rs).

--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ age-slp extract graphics/177.slp --palette interfac/50500.bin --player 3 --direc
 
 - `dat`, `scn` and `drs` format handling is directly based on [SiegeEngineers/genie-rs](https://github.com/SiegeEngineers/genie-rs).
 - SLP file format handling is based on the description at [SFTtech/openage](https://github.com/blob/9f13a91184e16af761fd9b654ff66cb3665261dd/doc/media/slp-files.md)
+- RMS parsing is based on the description in the [Random Map Scripting Guide](http://aok.heavengames.com/blacksmith/showfile.php?fileid=12178) by Bultro and Zetnus.
 

--- a/age-rms
+++ b/age-rms
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+
+from pypeg2.xmlast import thing2xml
+
+from libage.archive import archive
+from libage.rms import rms
+
+
+def validate_command(extract_args):
+    # Just
+    input_filename = extract_args.rms_file
+    f = rms.read(input_filename)
+    result_str = thing2xml(f, pretty=False, object_names=False)
+    print(result_str.decode('utf-8'))
+
+def main():
+    # General stuff
+    parser = argparse.ArgumentParser(description='Tool to parse AOE2 random map scripts (*.rms, *.rms2)')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
+    subparsers = parser.add_subparsers(help='action to be performed', dest='action', required=True)
+
+    # Extract command
+    parser_extract = subparsers.add_parser('validate', help='Check syntax of map script')
+    parser_extract.add_argument('rms_file', metavar='script.rms', help='the script to validate')
+    parser_extract.add_argument('--directory', type=str, help='output directory', default='.')
+    parser_extract.set_defaults(func=validate_command)
+
+    args = parser.parse_args()
+
+    # Set log level
+    if args.verbose > 1:
+        log_level = logging.DEBUG
+    elif args.verbose == 1:
+        log_level = logging.INFO
+    else:
+        log_level = logging.WARNING
+    logging.basicConfig(level=log_level)
+
+    # Call requested function
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/libage/rms/rms.py
+++ b/libage/rms/rms.py
@@ -31,5 +31,5 @@ def read(file_name: str):
     if not (file_name.lower().endswith(".rms") or file_name.lower().endswith(".rms2") or file_name.lower().endswith(".def") or file_name.lower().endswith(".inc")):
         raise Exception("Random map script file must end in .rms or .rms2. Included files must be .inc or .def.")
     with open(file_name, 'rb') as f:
-        # endoding: megarandom script has a rogue Latin-1 š on line 2807 which doesn't parse.
+        # encoding: megarandom script has a rogue Latin-1 š on line 2807, so fair to assume it's not UTF-8.
         return read_str(f.read().decode('iso-8859-1'), filename=file_name)

--- a/libage/rms/rms.py
+++ b/libage/rms/rms.py
@@ -2,207 +2,16 @@ from pypeg2 import *
 
 # Using C-style comment for now.
 # TODO: Actual game does not accept non-whitespace either side of /* and */
+from libage.rms.rms_common import commands
+
 comment_rms = re.compile(r"(?ms)/\*.*?\*/")
 
 # Commands are newline-delimited, cant ignore newlines completely
 whitespace_rms = re.compile("(?m)[ \t\r]+")
 
-newline = re.compile(r'\n+')
-
-command_argument = re.compile(r"[A-Za-z0-9_]+")  # constant or numeric literal
-
-
-class ConstDefinition(List):
-    constant_name_regex = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
-
-    grammar = "#const", attr("name", constant_name_regex), optional(attr("value", command_argument)), maybe_some(
-        newline)
-
-
-class CommandKeyword(Keyword):
-    grammar = Enum(
-        # Player setup stuff
-        K("ai_info_map_type"),
-        K("random_placement"),
-
-        # Land stuff
-        K("base_terrain"),
-
-        # create_land stuff
-        K("border_fuzziness"),
-        K("bottom_border"),
-        K("land_percent"),
-        K("land_position"),
-        K("left_border"),
-        K("number_of_tiles"),
-        K("right_border"),
-        K("terrain_type"),
-        K("top_border"),
-
-        # create_player_lands stuff
-        K("terrain_type"),
-        K("base_size"),
-        K("base_elevation"),
-        K("number_of_tiles"),
-        K("clumping_factor"),
-        K("other_zone_avoidance_distance"),
-        K("right_border"),
-        K("left_border"),
-        K("top_border"),
-        K("bottom_border"),
-        K("set_zone_by_team"),
-
-        # create_elevation stuff
-        K("number_of_clumps"),
-        K("set_scale_by_size"),
-
-        # create_terrain stuff
-        K("base_terrain"),
-        K("land_percent"),
-        K("number_of_clumps"),
-        K("clumping_factor"),
-        K("set_avoid_player_start_areas"),
-        K("spacing_to_other_terrain_types"),
-        K("set_scale_by_groups"),
-        K("height_limits"),
-
-        # create_object stuff
-        K("set_place_for_every_player"),
-        K("group_placement_radius"),
-        K("min_distance_to_players"),
-        K("max_distance_to_players"),
-        K("number_of_objects"),
-        K("number_of_groups"),
-        K("set_gaia_object_only"),
-        K("set_place_for_every_player"),
-        K("min_distance_to_players"),
-        K("min_distance_group_placement"),
-        K("set_loose_grouping"),
-        K("terrain_to_place_on"),
-        K("set_tight_grouping"),
-        K("temp_min_distance_group_placement"),
-        K("set_scaling_to_map_size"),
-
-        # Not really commands
-        K("start_random"),
-        K("percent_chance"),
-        K("end_random"),
-        K("if"),
-        K("elseif"),
-        K("else"),
-        K("endif")
-
-    )
-
-
-class BlockCommandKeyword(Keyword):
-    grammar = Enum(
-        K("create_land"),
-        K("create_player_lands"),
-        K("create_elevation"),
-        K("create_terrain"),
-        K("create_object")
-    )
-
-
-class Command(List):
-    # TODO capture arguments as a list here
-    grammar = attr("name", CommandKeyword), \
-              optional(attr("arg1", command_argument)), \
-              optional(attr("arg2", command_argument)), \
-              optional(attr("arg3", command_argument)), \
-              optional(attr("arg4", command_argument)), \
-              optional(attr("arg5", command_argument)), \
-              optional(attr("arg6", command_argument)), \
-              optional(attr("arg7", command_argument)), \
-              optional(attr("arg8", command_argument)), \
-              maybe_some(newline)
-
-
-class CommandBlock(List):
-    grammar = attr("name", BlockCommandKeyword), \
-              optional(attr("arg1", command_argument)), \
-              maybe_some(newline), \
-              "{", maybe_some([
-        Command,
-        newline
-    ]), "}", maybe_some(newline)
-
-
-class PlayerSetupSection(List):
-    grammar = '<PLAYER_SETUP>', maybe_some([
-        newline,
-        ConstDefinition,
-        CommandBlock,
-        Command
-    ])
-
-
-class LandGenerationSection(List):
-    grammar = '<LAND_GENERATION>', maybe_some([
-        newline,
-        ConstDefinition,
-        CommandBlock,
-        Command
-    ])
-
-
-class ElevationGenerationSection(List):
-    grammar = '<ELEVATION_GENERATION>', maybe_some([
-        newline,
-        ConstDefinition,
-        CommandBlock,
-        Command
-    ])
-
-
-class CliffGenerationSection(List):
-    grammar = '<CLIFF_GENERATION>', maybe_some([
-        newline,
-        ConstDefinition,
-        CommandBlock,
-        Command
-    ])
-
-
-class TerrainGernationSection(List):
-    grammar = '<TERRAIN_GENERATION>', maybe_some([
-        newline,
-        ConstDefinition,
-        CommandBlock,
-        Command
-    ])
-
-
-class ConnectionGenerationSection(List):
-    grammar = '<CONNECTION_GENERATION>', maybe_some([
-        newline,
-        ConstDefinition,
-        CommandBlock,
-        Command
-    ])
-
-
-class ObjectsGenerationSection(List):
-    grammar = '<OBJECTS_GENERATION>', maybe_some([
-        newline,
-        ConstDefinition,
-        CommandBlock,
-        Command
-    ])
-
 
 class RmsFile(List):
-    grammar = maybe_some([newline, ConstDefinition]), \
-              maybe_some([
-                  PlayerSetupSection,
-                  LandGenerationSection,
-                  ElevationGenerationSection,
-                  CliffGenerationSection,
-                  TerrainGernationSection,
-                  ConnectionGenerationSection,
-                  ObjectsGenerationSection
-              ])
+    grammar = maybe_some(commands)
 
 
 def read_str(content: str, filename=None) -> RmsFile:
@@ -215,9 +24,12 @@ def read_str(content: str, filename=None) -> RmsFile:
                  filename=filename)
 
 
-def read(path: str):
+def read(file_name: str):
     """
     Read from file
     """
-    with open(path, 'r') as f:
-        return read_str(f.read(), filename=path)
+    if not (file_name.lower().endswith(".rms") or file_name.lower().endswith(".rms2") or file_name.lower().endswith(".def") or file_name.lower().endswith(".inc")):
+        raise Exception("Random map script file must end in .rms or .rms2. Included files must be .inc or .def.")
+    with open(file_name, 'rb') as f:
+        # endoding: megarandom script has a rogue Latin-1 š on line 2807 which doesn't parse.
+        return read_str(f.read().decode('iso-8859-1'), filename=file_name)

--- a/libage/rms/rms.py
+++ b/libage/rms/rms.py
@@ -1,0 +1,223 @@
+from pypeg2 import *
+
+# Using C-style comment for now.
+# TODO: Actual game does not accept non-whitespace either side of /* and */
+comment_rms = re.compile(r"(?ms)/\*.*?\*/")
+
+# Commands are newline-delimited, cant ignore newlines completely
+whitespace_rms = re.compile("(?m)[ \t\r]+")
+
+newline = re.compile(r'\n+')
+
+command_argument = re.compile(r"[A-Za-z0-9_]+")  # constant or numeric literal
+
+
+class ConstDefinition(List):
+    constant_name_regex = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+
+    grammar = "#const", attr("name", constant_name_regex), optional(attr("value", command_argument)), maybe_some(
+        newline)
+
+
+class CommandKeyword(Keyword):
+    grammar = Enum(
+        # Player setup stuff
+        K("ai_info_map_type"),
+        K("random_placement"),
+
+        # Land stuff
+        K("base_terrain"),
+
+        # create_land stuff
+        K("border_fuzziness"),
+        K("bottom_border"),
+        K("land_percent"),
+        K("land_position"),
+        K("left_border"),
+        K("number_of_tiles"),
+        K("right_border"),
+        K("terrain_type"),
+        K("top_border"),
+
+        # create_player_lands stuff
+        K("terrain_type"),
+        K("base_size"),
+        K("base_elevation"),
+        K("number_of_tiles"),
+        K("clumping_factor"),
+        K("other_zone_avoidance_distance"),
+        K("right_border"),
+        K("left_border"),
+        K("top_border"),
+        K("bottom_border"),
+        K("set_zone_by_team"),
+
+        # create_elevation stuff
+        K("number_of_clumps"),
+        K("set_scale_by_size"),
+
+        # create_terrain stuff
+        K("base_terrain"),
+        K("land_percent"),
+        K("number_of_clumps"),
+        K("clumping_factor"),
+        K("set_avoid_player_start_areas"),
+        K("spacing_to_other_terrain_types"),
+        K("set_scale_by_groups"),
+        K("height_limits"),
+
+        # create_object stuff
+        K("set_place_for_every_player"),
+        K("group_placement_radius"),
+        K("min_distance_to_players"),
+        K("max_distance_to_players"),
+        K("number_of_objects"),
+        K("number_of_groups"),
+        K("set_gaia_object_only"),
+        K("set_place_for_every_player"),
+        K("min_distance_to_players"),
+        K("min_distance_group_placement"),
+        K("set_loose_grouping"),
+        K("terrain_to_place_on"),
+        K("set_tight_grouping"),
+        K("temp_min_distance_group_placement"),
+        K("set_scaling_to_map_size"),
+
+        # Not really commands
+        K("start_random"),
+        K("percent_chance"),
+        K("end_random"),
+        K("if"),
+        K("elseif"),
+        K("else"),
+        K("endif")
+
+    )
+
+
+class BlockCommandKeyword(Keyword):
+    grammar = Enum(
+        K("create_land"),
+        K("create_player_lands"),
+        K("create_elevation"),
+        K("create_terrain"),
+        K("create_object")
+    )
+
+
+class Command(List):
+    # TODO capture arguments as a list here
+    grammar = attr("name", CommandKeyword), \
+              optional(attr("arg1", command_argument)), \
+              optional(attr("arg2", command_argument)), \
+              optional(attr("arg3", command_argument)), \
+              optional(attr("arg4", command_argument)), \
+              optional(attr("arg5", command_argument)), \
+              optional(attr("arg6", command_argument)), \
+              optional(attr("arg7", command_argument)), \
+              optional(attr("arg8", command_argument)), \
+              maybe_some(newline)
+
+
+class CommandBlock(List):
+    grammar = attr("name", BlockCommandKeyword), \
+              optional(attr("arg1", command_argument)), \
+              maybe_some(newline), \
+              "{", maybe_some([
+        Command,
+        newline
+    ]), "}", maybe_some(newline)
+
+
+class PlayerSetupSection(List):
+    grammar = '<PLAYER_SETUP>', maybe_some([
+        newline,
+        ConstDefinition,
+        CommandBlock,
+        Command
+    ])
+
+
+class LandGenerationSection(List):
+    grammar = '<LAND_GENERATION>', maybe_some([
+        newline,
+        ConstDefinition,
+        CommandBlock,
+        Command
+    ])
+
+
+class ElevationGenerationSection(List):
+    grammar = '<ELEVATION_GENERATION>', maybe_some([
+        newline,
+        ConstDefinition,
+        CommandBlock,
+        Command
+    ])
+
+
+class CliffGenerationSection(List):
+    grammar = '<CLIFF_GENERATION>', maybe_some([
+        newline,
+        ConstDefinition,
+        CommandBlock,
+        Command
+    ])
+
+
+class TerrainGernationSection(List):
+    grammar = '<TERRAIN_GENERATION>', maybe_some([
+        newline,
+        ConstDefinition,
+        CommandBlock,
+        Command
+    ])
+
+
+class ConnectionGenerationSection(List):
+    grammar = '<CONNECTION_GENERATION>', maybe_some([
+        newline,
+        ConstDefinition,
+        CommandBlock,
+        Command
+    ])
+
+
+class ObjectsGenerationSection(List):
+    grammar = '<OBJECTS_GENERATION>', maybe_some([
+        newline,
+        ConstDefinition,
+        CommandBlock,
+        Command
+    ])
+
+
+class RmsFile(List):
+    grammar = maybe_some([newline, ConstDefinition]), \
+              maybe_some([
+                  PlayerSetupSection,
+                  LandGenerationSection,
+                  ElevationGenerationSection,
+                  CliffGenerationSection,
+                  TerrainGernationSection,
+                  ConnectionGenerationSection,
+                  ObjectsGenerationSection
+              ])
+
+
+def read_str(content: str, filename=None) -> RmsFile:
+    """
+    # Read from string
+    # """
+    return parse(content, RmsFile,
+                 comment=comment_rms,
+                 whitespace=whitespace_rms,
+                 filename=filename)
+
+
+def read(path: str):
+    """
+    Read from file
+    """
+    with open(path, 'r') as f:
+        return read_str(f.read(), filename=path)

--- a/libage/rms/rms_common.py
+++ b/libage/rms/rms_common.py
@@ -1,0 +1,245 @@
+from pypeg2 import *
+
+"""
+Elements which may appear anywhere in an RMS script
+"""
+
+
+class LiteralValue(str):
+    grammar = re.compile(r"((\d+(\.\d+)?)|(\.\d+))")
+
+
+class ConstValue(str):
+    grammar = re.compile(r"[A-Z]+[A-Za-z0-9_]*")
+
+
+class RandomValue(List):
+    grammar = "rnd(", csl(LiteralValue), ")"
+
+
+command_argument = [
+    LiteralValue,
+    ConstValue,
+    RandomValue
+]
+
+newline = ignore(re.compile(r'\n+'))
+
+"""
+Known commands
+"""
+
+
+class CommandKeyword(Keyword):
+    grammar = Enum(
+        K("ai_info_map_type"),
+        K("base_elevation"),
+        K("base_size"),
+        K("base_terrain"),
+        K("border_fuzziness"),
+        K("bottom_border"),
+        K("cliff_curliness"),
+        K("clumping_factor"),
+        K("group_placement_radius"),
+        K("group_variance"),
+        K("height_limits"),
+        K("land_percent"),
+        K("land_position"),
+        K("left_border"),
+        K("max_distance_to_other_zones"),
+        K("max_distance_to_players"),
+        K("max_length_of_cliff"),
+        K("max_number_of_cliffs"),
+        K("min_distance_cliffs"),
+        K("min_distance_group_placement"),
+        K("min_distance_to_players"),
+        K("min_length_of_cliff"),
+        K("min_number_of_cliffs"),
+        K("number_of_clumps"),
+        K("number_of_groups"),
+        K("number_of_objects"),
+        K("number_of_tiles"),
+        K("other_zone_avoidance_distance"),
+        K("random_placement"),
+        K("replace_terrain"),
+        K("right_border"),
+        K("set_avoid_player_start_areas"),
+        K("set_flat_elevation_only"),
+        K("set_flat_terrain_only"),
+        K("set_gaia_object_only"),
+        K("set_loose_grouping"),
+        K("set_place_for_every_player"),
+        K("set_scale_by_groups"),
+        K("set_scale_by_size"),
+        K("set_scaling_to_map_size"),
+        K("set_tight_grouping"),
+        K("set_zone_by_team"),
+        K("spacing_to_other_terrain_types"),
+        K("temp_min_distance_group_placement"),
+        K("terrain_cost"),
+        K("terrain_size"),
+        K("terrain_to_place_on"),
+        K("terrain_type"),
+        K("top_border"),
+        K("zone")
+    )
+
+
+"""
+All blocks (unknown blocks cannot be read)
+"""
+
+class BlockKeyword(Keyword):
+    grammar = Enum(
+        K("create_land"),
+        K("create_player_lands"),
+        K("create_elevation"),
+        K("create_terrain"),
+        K("create_object"),
+        K("create_connect_all_players_land")
+    )
+
+
+class SectionKeyword(Keyword):
+    grammar = Enum(
+        K("PLAYER_SETUP"),
+        K("LAND_GENERATION"),
+        K("ELEVATION_GENERATION"),
+        K("CLIFF_GENERATION"),
+        K("TERRAIN_GENERATION"),
+        K("CONNECTION_GENERATION"),
+        K("OBJECTS_GENERATION")
+    )
+
+
+class Command(List):
+    # Covers known commands
+    grammar = attr("name", CommandKeyword), \
+        maybe_some(command_argument)
+
+
+class UnknownCommand(List):
+    things_to_skip = "start_random|percent_chance|end_random|if|elseif|else|endif"
+    command_regex = re.compile(r"^(?!" + things_to_skip + ")[a-z]+[a-z0-9_]*")
+
+    grammar = attr("name", command_regex), \
+              optional(attr("arg1", command_argument)), \
+              optional(attr("arg2", command_argument)), \
+              optional(attr("arg3", command_argument)), \
+              optional(attr("arg4", command_argument)), \
+              optional(attr("arg5", command_argument)), \
+              optional(attr("arg6", command_argument)), \
+              optional(attr("arg7", command_argument)), \
+              optional(attr("arg8", command_argument))
+
+
+class BlockIdentifier(List):
+    # Covers known commands
+    grammar = attr("name", BlockKeyword), maybe_some(newline), optional(command_argument)
+
+
+"""
+Preprocessor-style commands
+"""
+
+
+class Define(List):
+    grammar = '#define', ConstValue
+
+
+class Const(List):
+    grammar = "#const", ConstValue, command_argument
+
+
+class Include(List):
+    filename_regex = re.compile(r"[A-Za-z_0-9\\.]+")
+
+    grammar = '#include_drs', attr("name", filename_regex), optional(attr("value", command_argument))
+
+
+"""
+Define all structures which can nest
+"""
+
+
+class RandomBranch(List):
+    pass
+
+
+class BlockCommands(List):
+    pass
+
+
+class If(List):
+    pass
+
+
+class ElseIf(List):
+    pass
+
+
+class Else(List):
+    pass
+
+
+class ConditionalBranch(List):
+    pass
+
+
+class RandomSection(List):
+    pass
+
+
+class Section(List):
+    pass
+
+
+commands = [
+    newline,
+    Section,
+    Define,
+    Const,
+    Include,
+    RandomBranch,
+    ConditionalBranch,
+    BlockCommands,
+    BlockIdentifier,
+    Command,
+    UnknownCommand
+]
+
+commands_but_not_sections = [
+    newline,
+    Define,
+    Const,
+    Include,
+    RandomBranch,
+    ConditionalBranch,
+    BlockCommands,
+    BlockIdentifier,
+    Command,
+    UnknownCommand
+]
+
+class Commands(List):
+    grammar = maybe_some(commands)
+
+class Weight(List):
+    grammar = optional(command_argument)
+
+class Condition(List):
+    grammar = optional(command_argument)
+
+BlockCommands.grammar = "{", maybe_some(commands), optional("}"), maybe_some(newline)
+
+# Random: start_random, percent_chance, end_random
+RandomBranch.grammar = "start_random", maybe_some(newline), maybe_some([newline, RandomSection]), "end_random"
+RandomSection.grammar = "percent_chance", Weight, Commands
+
+# Conditionals: if, elseif, else, endif.
+ConditionalBranch.grammar = "if", maybe_some(newline), If, maybe_some(ElseIf), optional(Else), optional("endif")
+If.grammar = Condition, Commands
+ElseIf.grammar = "elseif", maybe_some(newline), Condition, Commands
+Else.grammar = "else", Commands
+
+Section.grammar = '<', attr("name", Symbol), '>', maybe_some(commands_but_not_sections)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pefile
 Pillow
+pypeg2
 PyYAML
+

--- a/tests/test_rms.py
+++ b/tests/test_rms.py
@@ -1,0 +1,24 @@
+import inspect
+import os
+import unittest
+
+from pypeg2.xmlast import thing2xml
+
+from libage.rms import rms
+
+TEST_FILE_DIR = os.path.join(os.path.dirname(__file__), '..')
+
+
+class TestRmsFiles(unittest.TestCase):
+    def test_sections_only(self):
+        sections_only = inspect.cleandoc("""
+            <PLAYER_SETUP>
+            <LAND_GENERATION>
+            <ELEVATION_GENERATION>
+            <CLIFF_GENERATION>
+            <TERRAIN_GENERATION>
+            <CONNECTION_GENERATION>
+            <OBJECTS_GENERATION>
+            """)
+        f = rms.read_str(sections_only)
+        self.assertEqual(7, len(f))

--- a/tests/test_rms.py
+++ b/tests/test_rms.py
@@ -2,11 +2,9 @@ import inspect
 import os
 import unittest
 
-from pypeg2.xmlast import thing2xml
-
 from libage.rms import rms
 
-TEST_FILE_DIR = os.path.join(os.path.dirname(__file__), '..')
+TEST_FILE_DIR = os.path.join(os.path.dirname(__file__), '..', 'test_files')
 
 
 class TestRmsFiles(unittest.TestCase):
@@ -21,4 +19,32 @@ class TestRmsFiles(unittest.TestCase):
             <OBJECTS_GENERATION>
             """)
         f = rms.read_str(sections_only)
-        self.assertEqual(7, len(f))
+        self.assertEqual(7, len(f))   # The 7 named sections
+
+    def test_commented_block_close(self):
+        # Observed in mediterranean RMS, so I guess this is valid
+        test_str = inspect.cleandoc("""
+            <CONNECTION_GENERATION>
+            create_connect_all_players_land
+            {
+            /*  replace_terrain GRASS         DESERT
+            replace_terrain WATER         SHALLOW
+            } */
+            """)
+        f = rms.read_str(test_str)
+        self.assertEqual(1, len(f))
+
+    def test_random_probability(self):
+        # Observed rnd(x,y) in Serengeti RMS
+        test_str = inspect.cleandoc("""
+            create_terrain SOMETHING
+            {
+            base_terrain                   SOMETHING_ELSE
+            land_percent                   rnd(123,456)
+            }
+            """)
+        f = rms.read_str(test_str)
+        self.assertEqual("create_terrain", f[0].name)
+        self.assertEqual("land_percent", f[1][1].name)
+        self.assertEqual("123", f[1][1][0][0])
+        self.assertEqual("456", f[1][1][0][1])


### PR DESCRIPTION
Adds a `pypeg2`-based parser for AOE2 RMS scripts, plus some notes.

Example of cliff generation at the end of the parsed output for `Arabia.rms`.

![image](https://user-images.githubusercontent.com/2080552/95009289-90c50e00-066c-11eb-979c-c8f900d65be6.png)
