### PR TITLE
Fixes to scenario writer

### DIFF
--- a/libage/scenario/scenario.py
+++ b/libage/scenario/scenario.py
@@ -78,7 +78,7 @@ def load(file_name: str) -> ScenarioFile:
                 player_objects.append(obj)
             scenario_objects.append(player_objects)
 
-        UnknownDataStructure.read(data) # TODO store this
+        UnknownDataStructure.read(data)  # TODO store this
 
         return ScenarioFile(
             header,

--- a/libage/scenario/scn_engine_properties.py
+++ b/libage/scenario/scn_engine_properties.py
@@ -73,14 +73,17 @@ class ScnEngineProperties:
                 raise Exception("Mission BMP data not understood")
 
         for i in range(0, 16):
-            logging.debug("Player %d build list %s", i, data.string16())
+            player_build_list = data.string16()
+            logging.debug("Player %d build list %s", i, player_build_list)
 
         for i in range(0, 16):
-            logging.debug("Player %d city plan %s", i, data.string16())
+            player_city_plan = data.string16()
+            logging.debug("Player %d city plan %s", i, player_city_plan)
 
         if version >= 1.08:
             for i in range(0, 16):
-                logging.debug("Player %d personality %s", i, data.string16())
+                player_personality = data.string16()
+                logging.debug("Player %d personality %s", i, player_personality)
 
         for i in range(0, 16):
             """ Embedded files """
@@ -229,22 +232,25 @@ class ScnEngineProperties:
         if self.rge_version > 1.13:
             for i in range(0, 16):
                 # player names
-                data.string_fixed('Player name {}'.format(i), size=256)
+                data.string_fixed('', size=256)
 
         if self.rge_version > 1.16:
             raise Exception("Not implemented: player string table not understood")
 
         if self.rge_version > 1.13:
             for i in range(0, 16):
+                player_active = 1 if i < 2 else 0
+                player_type = 1 if i == 0 else 0
+                player_civ_id = i + 1
                 player_base = ScnPlayerBaseProperties(
-                    active=1,
-                    player_type=1,
-                    civilization=1,
+                    active=player_active,
+                    player_type=player_type,
+                    civilization=player_civ_id,
                     posture=4)
                 player_base.write(data)
 
         if self.rge_version > 1.07:
-            is_conquest = False
+            is_conquest = True
             data.boolean8(is_conquest)
 
         # Some check values?
@@ -252,7 +258,7 @@ class ScnEngineProperties:
         data.uint16(0)
         data.float32(0)
 
-        filename = 'example.scn'
+        filename = 'scenario.scx'
         data.string16(filename)
 
         if self.rge_version > 1.16:
@@ -277,15 +283,15 @@ class ScnEngineProperties:
         if self.rge_version > 1.22:
             raise Exception("Not implemented: scout data not understood")
 
-        pregame_cinematic = ""
+        pregame_cinematic = ' <None> '
         data.string16(pregame_cinematic)
-        victory_cinematic = ""
+        victory_cinematic = ' <None> '
         data.string16(victory_cinematic)
-        loss_cinematic = ""
+        loss_cinematic = ' <None> '
         data.string16(loss_cinematic)
 
         if self.rge_version >= 1.09:
-            mission_bmp = ""
+            mission_bmp = ' <None> '
             data.string16(mission_bmp)
 
         if self.rge_version >= 1.10:
@@ -295,20 +301,20 @@ class ScnEngineProperties:
              data.uint32(width)
              height = 0
              data.uint32(height)
-             orientation = 0
+             orientation = 1
              data.uint16(orientation)
 
         for i in range(0, 16):
-            player_build_list = ""
+            player_build_list = "Random"
             data.string16(player_build_list)
 
         for i in range(0, 16):
-            player_city_plan = ""
+            player_city_plan = ' <None> '
             data.string16(player_city_plan)
 
         if self.rge_version >= 1.08:
             for i in range(0, 16):
-                player_personality = ""
+                player_personality = "Random"
                 data.string16(player_personality)
 
         for i in range(0, 16):
@@ -322,7 +328,7 @@ class ScnEngineProperties:
                 data.uint32(ai_rules_length)
             else:
                 data.uint32(0)
-            # Would write build_list, city plan, AI rules if lens weren't 0
+            # Would write build_list, city plan, AI rules if len() wasn't 0
 
         if self.rge_version >= 1.20:
             raise Exception("Not implemented: AI rules not understood")

--- a/libage/scenario/scn_game_properties.py
+++ b/libage/scenario/scn_game_properties.py
@@ -17,12 +17,14 @@ class ScnGameProperties:
         if version <= 1.13:
             for i in range(0, 16):
                 # skip past player names
-                data.string_fixed(size=256)
+                player_name = data.string_fixed(size=256)
             raise Exception("Not implemented: Don't know how to read player base properties from <1.13 file")
         else:
+            player_start_resources = []
             for i in range(0, 16):
                 # Ignoring at the moment
-                res = ScnPlayerStartResources.read(data, version)
+                this_player_start_resources = ScnPlayerStartResources.read(data, version)
+                player_start_resources.append(this_player_start_resources)
 
         if version >= 1.02:
             check5 = data.int32()
@@ -51,7 +53,7 @@ class ScnGameProperties:
         for i in range(0, 16):
             for j in range(0, 12):
                 # TODO read these ???
-                data.read(60)
+                individual_victory_blob = data.read(60)
 
         if version >= 1.02:
             check5 = data.int32()
@@ -60,7 +62,7 @@ class ScnGameProperties:
 
         # Allied victory
         for i in range(0, 16):
-            data.uint32()
+            allied_victory = data.uint32()
 
         if version >= 1.24:
             raise Exception("Not implemented: Don't know how to read team information from >=1.24 file")
@@ -176,9 +178,9 @@ class ScnGameProperties:
             for i in range(0, 16):
                 # Not based on real info at the moment
                 res = ScnPlayerStartResources(
+                    gold=0,
                     food=200,
                     wood=200,
-                    gold=0,
                     stone=150,
                     ore=0,
                     goods=0,
@@ -189,7 +191,7 @@ class ScnGameProperties:
         if version >= 1.02:
             data.int32(-99)  # check
 
-        victory_conquest = 0
+        victory_conquest = 1
         data.uint32(victory_conquest)
         victory_ruins = 0
         data.uint32(victory_ruins)
@@ -201,27 +203,28 @@ class ScnGameProperties:
         data.uint32(victory_exploration)
         victory_gold = 0
         data.uint32(victory_gold)
-        victory_all_flag = 0
+        victory_all_flag = False
         data.boolean32(victory_all_flag)
 
         if version >= 1.13:
             mp_victory_type = 0
             data.uint32(mp_victory_type)
-            victory_score = 0
+            victory_score = 900
             data.uint32(victory_score)
-            victory_time = 0
+            victory_time = 9000
             data.uint32(victory_time)
 
         for i in range(0, 16):
             for j in range(0, 16):
                 # stance from player i to j
-                diplomatic_stance = 0
+                diplomatic_stance = 3  # 3 is enemy ?
                 data.uint32(diplomatic_stance)
 
         # 12 victory conditions for each player
         for i in range(0, 16):
             for j in range(0, 12):
                 # TODO write these ???
+                # all 0's on blank map.
                 data.string_fixed('', size=60)
 
         if version >= 1.02:
@@ -229,7 +232,8 @@ class ScnGameProperties:
 
         # Allied victory
         for i in range(0, 16):
-            data.uint32(0)
+            allied_victory = 0
+            data.uint32(allied_victory)
 
         if version >= 1.24:
             raise Exception("Not implemented: Don't know how to read team information from >=1.24 file")
@@ -241,7 +245,7 @@ class ScnGameProperties:
             for i in range(0, 16):
                 for j in range(0, 20):
                     # disabled tech player i, position j
-                    disabled_tech_id = 0
+                    disabled_tech_id = 1
                     data.uint32(disabled_tech_id)
 
         if version > 1.04:

--- a/libage/scenario/scn_player_start_resources.py
+++ b/libage/scenario/scn_player_start_resources.py
@@ -5,8 +5,8 @@ from libage.scenario.data import ScnDataReader, ScnDataWriter
 
 @dataclass
 class ScnPlayerStartResources:
-    wood: int
     gold: int
+    wood: int
     food: int
     stone: int
     ore: int
@@ -16,8 +16,8 @@ class ScnPlayerStartResources:
     @staticmethod
     def read(data: ScnDataReader, version: float):
         return ScnPlayerStartResources(
-            wood=data.uint32(),
             gold=data.uint32(),
+            wood=data.uint32(),
             food=data.uint32(),
             stone=data.uint32(),
             ore=data.uint32() if version >= 1.17 else 0,
@@ -26,8 +26,8 @@ class ScnPlayerStartResources:
         )
 
     def write(self, data: ScnDataWriter, version: float):
-        data.uint32(self.wood),
         data.uint32(self.gold),
+        data.uint32(self.wood),
         data.uint32(self.food),
         data.uint32(self.stone),
         if version >= 1.17:


### PR DESCRIPTION
Fixes to scenario writer, eg.

```
./venv/bin/python3 age-scenario create scenario.scx --size 144
```

The generated (blank) scenarios can now be played through **Single Player** -> **Scenario**, where this previously crashed the game. Values mostly match the defaults in the scenario editor.

Also fixes:

- Starting resources
- Tech tree - everything was disabled before
- Diplomacy - everybody was allied before
- Conquest victory condition - game never ended before, even if you defeated all other players

